### PR TITLE
Remove dependency to openssl gem and allow older ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: ruby
 
 rvm:
-  - 2.3.3
-  - 2.4.0
+  - 2.1.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 
 before_install:
   - gem update --system # https://github.com/bundler/bundler/issues/5357

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next version
 - Your contribution!
+- Remove `openssl` gem dependency
+- Lower minimal ruby version to 2.1.0
 
 # Version 1.0.3
 - Bump minimal ruby version to 2.3.0

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Generate the [Trustpilot Business Generated Links](https://support.trustpilot.com/hc/en-us/articles/115002337108-Trustpilot-s-Business-Generated-Links-) in ruby.
 
 ## Requirements
-- Ruby 2.3.0 or newer
+Ruby 2.1.0 or newer. It probably works on lower versions but has not been tested and is not supported.
 
 ## Installation
 `gem install trustpilot-business-links`

--- a/trustpilot-business-links.gemspec
+++ b/trustpilot-business-links.gemspec
@@ -16,14 +16,12 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.3.0'
-
-  s.add_dependency 'openssl', '~> 2.1'
+  s.required_ruby_version = '>= 2.1.0'
 
   s.add_development_dependency 'pry', '~> 0.11'
   s.add_development_dependency 'ci_reporter', '~> 2.0'
   s.add_development_dependency 'ci_reporter_rspec', '~> 1.0'
-  s.add_development_dependency 'rack-test', '~> 0.7'
+  s.add_development_dependency 'rack-test', '~> 0.5'
   s.add_development_dependency 'rake', '~> 12.2'
   s.add_development_dependency 'rspec', '~> 3.6'
   s.add_development_dependency 'rspec-its', '~> 1.2'


### PR DESCRIPTION
* The openssl module embedded in ruby is enough.
* We don't use fancy features of ruby, so it should work in ruby 1.9 too.